### PR TITLE
Add proper `SensorException`

### DIFF
--- a/sensorlib.r2py
+++ b/sensorlib.r2py
@@ -26,6 +26,13 @@ AP_PORT = 45678
 mycontext['id'] = 0
 
 
+class SensorException(RepyException):
+  """This exception gets raised when reading a sensor results in an error.
+  """
+  pass
+
+
+
 def usage():
   log("""
 Something went wrong in your code..
@@ -102,7 +109,7 @@ def request_data(sl4a_socket, method, args):
 
   if error != None:
     log("Something went wrong!\n")
-    raise
+    raise SensorException(error)
   else:
     result = parsed['result']
     return result


### PR DESCRIPTION
Using `raise` without an argument causes an error in the Repy runtime that looks like this:

```
Uncaught exception!

---
Following is a full traceback, and a user traceback.
The user traceback excludes non-user modules. The most recent call is displayed last.

Full debugging traceback:
  "repyV2/repy.py", line 177, in execute_namespace_until_completion
  "/mnt/sdcard/Android/data/com.sensibility_testbed/files/sl4a/seattle/seattle_repy/repyV2/virtual_namespace.py", line 117, in evaluate
  "/mnt/sdcard/Android/data/com.sensibility_testbed/files/sl4a/seattle/seattle_repy/repyV2/safe.py", line 588, in safe_run
  "dylink.r2py", line 547, in <module>
  "dylink.r2py", line 408, in dylink_dispatch
  "dylink.r2py", line 521, in evaluate
  "/mnt/sdcard/Android/data/com.sensibility_testbed/files/sl4a/seattle/seattle_repy/repyV2/virtual_namespace.py", line 117, in evaluate
  "/mnt/sdcard/Android/data/com.sensibility_testbed/files/sl4a/seattle/seattle_repy/repyV2/safe.py", line 588, in safe_run
  "location.r2py", line 66, in <module>
  "/mnt/sdcard/Android/data/com.sensibility_testbed/files/sl4a/seattle/seattle_repy/repyV2/namespace.py", line 1220, in wrapped_function
  "/mnt/sdcard/Android/data/com.sensibility_testbed/files/sl4a/seattle/seattle_repy/repyV2/namespace.py", line 218, in _handle_internalerror
  "/mnt/sdcard/Android/data/com.sensibility_testbed/files/sl4a/seattle/seattle_repy/repyV2/tracebackrepy.py", line 209, in handle_internalerror
  "/mnt/sdcard/Android/data/com.sensibility_testbed/files/sl4a/seattle/seattle_repy/repyV2/safe.py", line 493, in exceptionraiser

User traceback:
  "dylink.r2py", line 547, in <module>
  "dylink.r2py", line 408, in dylink_dispatch
  "dylink.r2py", line 521, in evaluate
  "location.r2py", line 66, in <module>

Unsafe call: ("Unsafe call '__import__' with args '('servicelogger', {'handle_internalerror': <function handle_internalerror at 0x40668130>, 
```

(followed by lots of definitions available in the function scope, etc.)

Patching as proposed in https://github.com/SeattleTestbed/repy_v2/issues/92#issuecomment-57157372 shows what the actual problem is:

```
Something went wrong!

---
Uncaught exception!

---
Following is a full traceback, and a user traceback.
The user traceback excludes non-user modules. The most recent call is displayed last.

Full debugging traceback:
  "repyV2/repy.py", line 177, in execute_namespace_until_completion
  "/mnt/sdcard/Android/data/com.sensibility_testbed/files/sl4a/seattle/seattle_repy/repyV2/virtual_namespace.py", line 117, in evaluate
  "/mnt/sdcard/Android/data/com.sensibility_testbed/files/sl4a/seattle/seattle_repy/repyV2/safe.py", line 588, in safe_run
  "dylink.r2py", line 547, in <module>
  "dylink.r2py", line 408, in dylink_dispatch
  "dylink.r2py", line 521, in evaluate
  "/mnt/sdcard/Android/data/com.sensibility_testbed/files/sl4a/seattle/seattle_repy/repyV2/virtual_namespace.py", line 117, in evaluate
  "/mnt/sdcard/Android/data/com.sensibility_testbed/files/sl4a/seattle/seattle_repy/repyV2/safe.py", line 588, in safe_run
  "location.r2py", line 53, in <module>
  "sensorlib.r2py", line 107, in request_data

User traceback:
  "dylink.r2py", line 547, in <module>
  "dylink.r2py", line 408, in dylink_dispatch
  "dylink.r2py", line 521, in evaluate
  "location.r2py", line 53, in <module>
  "sensorlib.r2py", line 107, in request_data

Exception (with type 'exceptions.TypeError'): exceptions must be old-style classes or derived from BaseException, not NoneType

---
```

This commit fixes the complaint about exceptions, making the traceback look like this:

```
Uncaught exception!

---
Following is a full traceback, and a user traceback.
The user traceback excludes non-user modules. The most recent call is displayed last.

Full debugging traceback:
  "repyV2/repy.py", line 177, in execute_namespace_until_completion
  "/mnt/sdcard/Android/data/com.sensibility_testbed/files/sl4a/seattle/seattle_repy/repyV2/virtual_namespace.py", line 117, in evaluate
  "/mnt/sdcard/Android/data/com.sensibility_testbed/files/sl4a/seattle/seattle_repy/repyV2/safe.py", line 588, in safe_run
  "dylink.r2py", line 547, in <module>
  "dylink.r2py", line 408, in dylink_dispatch
  "dylink.r2py", line 521, in evaluate
  "/mnt/sdcard/Android/data/com.sensibility_testbed/files/sl4a/seattle/seattle_repy/repyV2/virtual_namespace.py", line 117, in evaluate
  "/mnt/sdcard/Android/data/com.sensibility_testbed/files/sl4a/seattle/seattle_repy/repyV2/safe.py", line 588, in safe_run
  "location.r2py", line 53, in <module>
  "sensorlib.r2py", line 114, in request_data

User traceback:
  "dylink.r2py", line 547, in <module>
  "dylink.r2py", line 408, in dylink_dispatch
  "dylink.r2py", line 521, in evaluate
  "location.r2py", line 53, in <module>
  "sensorlib.r2py", line 114, in request_data

Exception (with class '.SensorException'): java.io.IOException: Service not Available

---
```
